### PR TITLE
Streamlink args

### DIFF
--- a/mlbstreamer/config.py
+++ b/mlbstreamer/config.py
@@ -150,11 +150,6 @@ class Config(MutableMapping):
             player = " ".join([player, player_args])
 
         self.player = player
-	
-        streamlink_args = prompt(
-            "If you need to pass additional arguments to streamlink"
-            ", enter them here: ")
-        self.streamlink_args = streamlink_args
 
         print("Your system time zone seems to be %s." %(tz_local))
         if not confirm("Is that the time zone you'd like to use? (y/n) "):

--- a/mlbstreamer/config.py
+++ b/mlbstreamer/config.py
@@ -150,6 +150,11 @@ class Config(MutableMapping):
             player = " ".join([player, player_args])
 
         self.player = player
+	
+        streamlink_args = prompt(
+            "If you need to pass additional arguments to streamlink"
+            ", enter them here: ")
+        self.streamlink_args = streamlink_args
 
         print("Your system time zone seems to be %s." %(tz_local))
         if not confirm("Is that the time zone you'd like to use? (y/n) "):

--- a/mlbstreamer/play.py
+++ b/mlbstreamer/play.py
@@ -64,7 +64,7 @@ def play_stream(game_id, resolution,
         resolution,
     ]
     if config.settings.streamlink_args:
-	    cmd +=[config.settings.streamlink_args]
+	    cmd +=config.settings.streamlink_args.split(' ')
     if offset:
         cmd += ["--hls-start-offset", offset]
     logger.debug(" ".join(cmd))

--- a/mlbstreamer/play.py
+++ b/mlbstreamer/play.py
@@ -63,6 +63,8 @@ def play_stream(game_id, resolution,
         media_url,
         resolution,
     ]
+    if config.settings.streamlink_args:
+	    cmd +=[config.settings.streamlink_args]
     if offset:
         cmd += ["--hls-start-offset", offset]
     logger.debug(" ".join(cmd))


### PR DESCRIPTION
This commit add possibility to pass custom options to streamlink.
One particularly useful option is "hls-segment threads". Without using it MLB.tv streams are almost always choppy and laggy in my case.
Other options may or may not be useful, but I think it does not hurt anybody if users will be able to play with them by themselves.