### PR TITLE
Set fixed timezone to US/Eastern

### DIFF
--- a/mlbstreamer/play.py
+++ b/mlbstreamer/play.py
@@ -7,6 +7,7 @@ import pytz
 import subprocess
 import argparse
 from datetime import datetime, timedelta
+import pytz
 
 import dateutil.parser
 
@@ -87,7 +88,7 @@ def valid_date(s):
 
 def main():
 
-    today = datetime.now().date()
+    today = datetime.now(pytz.timezone('US/Eastern')).date() 
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", "--date", help="game date",


### PR DESCRIPTION
As I was watching in Central Europe the date was turning to 31th of March while watching a game. Reopening the stream wasn't working because the clock of the MLB API was still at 30th of March returning no games to be scheduled.

By setting the date back to 30th of March using the command line flag the game was streaming again.

This pull requests statically sets the timezone to US/Eastern where-ever the viewer might be. Therefore, preventing problems with different "todays" between US/Eastern and other time zones.