### PR TITLE
Log message rephrasing and fixed logging for play.py

### DIFF
--- a/mlbstreamer/play.py
+++ b/mlbstreamer/play.py
@@ -133,7 +133,6 @@ def play_stream(game_specifier, resolution,
 	    cmd +=config.settings.streamlink_args.split(' ')
     if offset:
         cmd += ["--hls-start-offset", offset]
-    logger.debug(" ".join(cmd))
 
     if output is not None:
         if output == True or os.path.isdir(output):
@@ -149,7 +148,7 @@ def play_stream(game_specifier, resolution,
 
         cmd += ["-o", outfile]
 
-    logger.debug(cmd)
+    logger.debug("Running cmd: %s" % " ".join(cmd))
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     return proc
 
@@ -218,6 +217,7 @@ def main():
                         help="team abbreviation or MLB game ID")
     options, args = parser.parse_known_args()
 
+    global logger
     logger = logging.getLogger("mlbstreamer")
     if options.verbose:
         logger.setLevel(logging.DEBUG)

--- a/mlbstreamer/session.py
+++ b/mlbstreamer/session.py
@@ -135,7 +135,7 @@ class MLBSession(object):
 
     def login(self):
 
-        logger.debug("attempting to log in")
+        logger.debug("checking for existing log in")
 
         initial_url = ("https://secure.mlb.com/enterworkflow.do"
                        "?flowId=registration.wizard&c_id=mlb")
@@ -155,7 +155,7 @@ class MLBSession(object):
             logger.debug("already logged in")
             return
 
-        logger.debug("sucessfully logged in")
+        logger.debug("attempting new log in")
 
         login_url = "https://securea.mlb.com/authenticate.do"
 

--- a/mlbstreamer/session.py
+++ b/mlbstreamer/session.py
@@ -135,7 +135,7 @@ class MLBSession(object):
 
     def login(self):
 
-        logger.debug("logging in")
+        logger.debug("attempting to log in")
 
         initial_url = ("https://secure.mlb.com/enterworkflow.do"
                        "?flowId=registration.wizard&c_id=mlb")
@@ -154,7 +154,8 @@ class MLBSession(object):
         if self.logged_in:
             logger.debug("already logged in")
             return
-        logger.debug("logging in")
+
+        logger.debug("sucessfully logged in")
 
         login_url = "https://securea.mlb.com/authenticate.do"
 


### PR DESCRIPTION
Rephrased and reduced some log messages.

I also made `logger` global in `play.py`. Before this the logger object would have not been initialized globally in `play.py`. Only for the function. Instead whenever accessing a function the standard non initialized logger instance was used, not logging any log messages. This wasn't a problem for the usual running through `mlbplay`. It wasn't logging anything when I was locally testing with `python -m mlbstreamer.play -v -r 224p -p -d 2018-03-30 nyy`.

The logging through `mlbplay` still works though.