### PR TITLE
Pass on verbose options to streamlink and ffmpeg

### DIFF
--- a/mlbstreamer/play.py
+++ b/mlbstreamer/play.py
@@ -28,7 +28,7 @@ def play_stream(game_specifier, resolution,
                 offset_from_beginning=None,
                 preferred_stream=None,
                 output=None,
-                date_json=None):
+                date_json=None, verbose=False):
 
     live = False
     offset = None
@@ -130,8 +130,12 @@ def play_stream(game_specifier, resolution,
         media_url,
         resolution,
     ]
+
     if config.settings.streamlink_args:
         cmd += shlex.split(config.settings.streamlink_args)
+
+    if verbose:
+        cmd += ['-v', '-l', 'debug', '--ffmpeg-verbose']
 
     if offset:
         cmd += ["--hls-start-offset", offset]
@@ -151,7 +155,7 @@ def play_stream(game_specifier, resolution,
         cmd += ["-o", outfile]
 
     logger.debug("Running cmd: %s" % " ".join(cmd))
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    proc = subprocess.Popen(cmd)
     return proc
 
 # def get_date_json(game_id, date_json):
@@ -256,6 +260,7 @@ def main():
             offset_from_beginning = options.beginning,
             preferred_stream = preferred_stream,
             output = options.save_stream,
+            verbose = options.verbose
         )
         proc.wait()
     except MLBPlayInvalidArgumentError as e:


### PR DESCRIPTION
This passes the verbose and debug options off to streamlink. It also instructs streamlink to pass debug options to ffmpeg.

This produces quite a lot of output so maybe we want to have separate verbose and debug flags? (or just make -v into `action="count"`

I removed `stdout=subprocess.PIPE` to `subprocess.Popen()` since that can cause a deadlock in combination with `proc.wait()`if the process generates a lot of output (which it does with -v)