### PR TITLE
Fix to available teamcodes. 

### DIFF
--- a/mlbstreamer/play.py
+++ b/mlbstreamer/play.py
@@ -75,7 +75,7 @@ def play_stream(game_specifier, resolution,
 
         with state.session.cache_responses_long():
             teams = AttrDict(
-                (team["abbreviation"].lower(), team["id"])
+                (team["teamCode"].lower(), team["id"])
                 for team in sorted(state.session.get(teams_url).json()["teams"],
                                    key=lambda t: t["fileCode"])
             )


### PR DESCRIPTION
Fixes problem with picking Los Angeles Angels streams. With code "laa" it pick stream of opponent team. It should be "ana" instead.