### PR TITLE
Link to Arch Linux AUR packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ To upgrade, just add `-U`:
 This installation method should pull down all the necessary dependencies from
 PyPI.
 
+For Arch Linux users, `mlbstreamer` can be installed from the AUR. The latest
+release is in the [mlbstreamer](https://aur.archlinux.org/packages/mlbstreamer/)
+package, and the development version in the
+[mlbstreamer-git](https://aur.archlinux.org/packages/mlbstreamer-git/) package.
+
+
 Configuration
 -------------
 


### PR DESCRIPTION
I've added build files to the [Arch User Repository](https://wiki.archlinux.org/index.php/Arch_User_Repository) so any Arch Linux users can install mlbstreamer with the package manager rather than pip. Several of the dependencies which weren't previously packaged were also added to the AUR.